### PR TITLE
persist: retry transient errors instead of dropping blueprint

### DIFF
--- a/src/io/input.rs
+++ b/src/io/input.rs
@@ -53,6 +53,7 @@ pub fn open_and_query_capabilities(pre_input_devices: Vec<PreInputDevice>)
                                     pre_device,
                                     capabilities,
                                     name: None,
+                                    error_retries: 0,
                                 });
                             },
                             // If they are not found, then the best thing we could either exit with an error, or assume
@@ -67,7 +68,9 @@ pub fn open_and_query_capabilities(pre_input_devices: Vec<PreInputDevice>)
                                     device_cache.location.display(),
                                 );
 
-                                blueprints.push(Blueprint { pre_device, capabilities: Capabilities::new(), name: None })
+                                blueprints.push(Blueprint {
+                                    pre_device, capabilities: Capabilities::new(), name: None, error_retries: 0,
+                                })
                             },
                             CachedCapabilities::Corrupted => {
                                 eprintln!(
@@ -76,7 +79,9 @@ pub fn open_and_query_capabilities(pre_input_devices: Vec<PreInputDevice>)
                                     device_cache.location.display(),
                                 );
 
-                                blueprints.push(Blueprint { pre_device, capabilities: Capabilities::new(), name: None })
+                                blueprints.push(Blueprint {
+                                    pre_device, capabilities: Capabilities::new(), name: None, error_retries: 0,
+                                })
                             },
                         }
                     },
@@ -351,6 +356,7 @@ impl InputDevice {
                 domain: self.domain,
                 persist_state: self.persist_state,
             },
+            error_retries: 0,
         }
     }
 }

--- a/src/persist/blueprint.rs
+++ b/src/persist/blueprint.rs
@@ -13,6 +13,9 @@ pub struct Blueprint {
     /// if the input device ends up having a different name than specified here, it is just cause to issue
     /// a warning to help find problematic setups.
     pub name: Option<InputDeviceName>,
+    /// Counts how many times in a row try_open() has returned an Error for this blueprint. Used to
+    /// bound how long we keep retrying a device that keeps failing to open with a hard error.
+    pub error_retries: u32,
 }
 
 pub enum TryOpenBlueprintResult {
@@ -20,7 +23,10 @@ pub enum TryOpenBlueprintResult {
     Success(InputDevice),
     /// Represents that the blueprint could not be opened right now, but you may try again later.
     NotOpened(Blueprint),
-    /// Represents an error of sufficient magnitude that you should not try opening this blueprint again.
+    /// Represents an error while trying to open the blueprint. This does not necessarily mean that
+    /// the blueprint should be dropped immediately: some such errors are transient (e.g. a device
+    /// node that briefly exists with restrictive permissions before udev applies its rules), so the
+    /// caller is expected to retry a bounded number of times before giving up.
     Error(Blueprint, SystemError),
 }
 
@@ -37,6 +43,7 @@ impl Blueprint {
                     pre_device,
                     capabilities: self.capabilities,
                     name: self.name,
+                    error_retries: self.error_retries,
                 }, error);
             },
         };

--- a/src/persist/subsystem.rs
+++ b/src/persist/subsystem.rs
@@ -205,6 +205,9 @@ impl Daemon {
     ///    successfully opened devices to just disappear if an error happened later.
     fn try_open(&mut self) -> TryOpenResult {
         const MAX_TRIES: usize = 5;
+        // Bounds how many times in a row a blueprint may fail to open with a hard Error before we
+        // give up on it entirely, so a truly broken device does not get retried forever.
+        const MAX_ERROR_RETRIES: u32 = 60;
         let mut result = TryOpenResult {
             opened_devices: Vec::new(),
             broken_blueprints: Vec::new(),
@@ -218,9 +221,21 @@ impl Daemon {
                 match blueprint.try_open() {
                     TryOpenBlueprintResult::Success(device) => result.opened_devices.push(device),
                     TryOpenBlueprintResult::NotOpened(blueprint) => remaining_blueprints.push(blueprint),
-                    TryOpenBlueprintResult::Error(blueprint, error) => {
+                    TryOpenBlueprintResult::Error(mut blueprint, error) => {
                         error.print_err();
-                        result.broken_blueprints.push(blueprint);
+
+                        // Some errors are transient, e.g. on some systems a reconnected device node
+                        // is briefly owned by root until udev applies the appropriate ACL, which
+                        // causes a spurious permission error here. Retry a bounded number of times
+                        // instead of dropping the blueprint on the very first error, but still give
+                        // up eventually in case the error turns out to be permanent.
+                        blueprint.error_retries += 1;
+                        if blueprint.error_retries > MAX_ERROR_RETRIES {
+                            eprintln!("Giving up on reopening a device after {} failed attempts.", blueprint.error_retries);
+                            result.broken_blueprints.push(blueprint);
+                        } else {
+                            remaining_blueprints.push(blueprint);
+                        }
                     }
                 }
             }


### PR DESCRIPTION

Hi Kars,

While using evsieve's persistence feature on a Steam Deck (SteamOS) to
merge a Bluetooth gamepad's input with other devices, I ran into a bug
where forwarding from the pad permanently stops after a Bluetooth
disconnect/reconnect cycle, even though evsieve itself and its virtual
output device keep running fine.

### Root cause

When the Bluetooth pad reconnects, the kernel creates the new
`/dev/input/eventN` node before udev has had a chance to run and apply
the `uaccess` ACL that grants the logged-in user (and therefore
evsieve) permission to open it. For a short window — in my testing,
roughly 1 second — the node exists but is owned by root, so opening it
fails with `EACCES`.

`Daemon::try_open()` in `src/persist/subsystem.rs` treats *any*
`TryOpenBlueprintResult::Error` as terminal: the very first failed
open moves the blueprint straight into `broken_blueprints`, which
reports `Report::BlueprintDropped` and permanently stops evsieve from
ever trying to reopen that device again. Since this happens on the
very first `EACCES` — before udev has finished settling — a perfectly
healthy, about-to-be-usable device gets permanently dropped.

### Observed log sequence (with a build that added extra tracing)

```
<pad disconnects>
persist: error reopening blueprint: EACCES ...   (attempt 1)
persist: error reopening blueprint: EACCES ...   (attempt 2)
persist: error reopening blueprint: EACCES ...   (attempt 3)
persist: error reopening blueprint: EACCES ...   (attempt 4)
persist: error reopening blueprint: EACCES ...   (attempt 5)
<~1s later, udev applies the uaccess ACL>
<pad reconnects successfully, forwarding resumes>
```

Without the fix, the very first `EACCES` in that sequence would have
dropped the blueprint and forwarding for that device would never come
back for the rest of the process's life.

I also confirmed that the pre-existing "capabilities differ on
reconnect" handling in `Blueprint::try_open()` (the warning path when
`input_device.capabilities() != self.capabilities`) is unaffected and
continues to work as designed — this fix only touches the
error-handling branch, not the success path.

### Fix

Added an `error_retries` counter on `Blueprint`, incremented each time
`try_open()` returns `Error`. Instead of moving the blueprint to
`broken_blueprints` on the first error, `Daemon::try_open()` now
treats it similarly to `NotOpened` (i.e. retry later) until the
counter exceeds a bound (`MAX_ERROR_RETRIES`), at which point the
blueprint is dropped exactly as before. This preserves the existing
behavior for devices that are genuinely gone/broken, while giving
transient permission races during udev settling a chance to resolve
themselves.

I picked a fairly generous bound since the retry loop is cheap and
only runs when inotify tells us the device path changed; happy to
adjust the constant, use a time-based bound instead of a count-based
one, or take a different approach entirely if you'd prefer — I mostly
wanted to get the underlying bug and the reproduction context in front
of you. I'm also glad to add a test or CHANGELOG entry if that's
useful, just let me know your conventions.

### Testing

- Verified the failure and the fix by hand on a Steam Deck (SteamOS),
  triggering repeated Bluetooth gamepad disconnect/reconnect cycles.
  Without the fix, the first reconnect after evsieve started
  permanently killed forwarding for that pad. With the fix, evsieve
  recovers automatically each time, typically within about a second
  and 5-6 failed open attempts.
- No automated test suite is included in this repo as far as I could
  tell; happy to add one if you point me at the right harness/pattern.

Thanks for evsieve, it's been very useful for this setup.
